### PR TITLE
better es6 export

### DIFF
--- a/dist/es6.tmpl.js
+++ b/dist/es6.tmpl.js
@@ -1,7 +1,7 @@
 
 /**
  * The riot template engine
- * @version v2.3.19
+ * @version WIP
  */
 
 /**
@@ -12,6 +12,7 @@
  * `brackets.set     ` Change the current riot brackets
  */
 
+export
 var brackets = (function (UNDEF) {
 
   var
@@ -205,6 +206,7 @@ var brackets = (function (UNDEF) {
  * tmpl.loopKeys - Get the keys for an 'each' loop (used by `_each`)
  */
 
+export
 var tmpl = (function () {
 
   var _cache = {}
@@ -407,7 +409,5 @@ var tmpl = (function () {
 
 })()
 
-  tmpl.version = brackets.version = 'v2.3.19'
-
-export default {tmpl, brackets}
+  tmpl.version = brackets.version = 'WIP'
 

--- a/dist/riot.tmpl.js
+++ b/dist/riot.tmpl.js
@@ -1,7 +1,7 @@
 
 /**
  * The riot template engine
- * @version v2.3.19
+ * @version WIP
  */
 
 /**
@@ -407,5 +407,5 @@ var tmpl = (function () {
 
 })()
 
-  tmpl.version = brackets.version = 'v2.3.19'
+  tmpl.version = brackets.version = 'WIP'
 

--- a/dist/tmpl.js
+++ b/dist/tmpl.js
@@ -1,4 +1,4 @@
-/* riot-tmpl v2.3.19, @license MIT, (c) 2015 Muut Inc. + contributors */
+/* riot-tmpl WIP, @license MIT, (c) 2015 Muut Inc. + contributors */
 ;(function (window) {
   'use strict'              // eslint-disable-line
 
@@ -405,7 +405,7 @@
 
   })()
 
-  tmpl.version = brackets.version = 'v2.3.19'
+  tmpl.version = brackets.version = 'WIP'
 
   /* istanbul ignore else */
   if (typeof module === 'object' && module.exports) {
@@ -426,4 +426,3 @@
   }
 
 })(typeof window === 'object' ? /* istanbul ignore next */ window : void 0) // eslint-disable-line no-void
-

--- a/lib/brackets.js
+++ b/lib/brackets.js
@@ -24,8 +24,10 @@ var
   $_RIX_RAW   = 10
 //#endif
 
+//#if ES6
+export
+//#endif
 var brackets = (function (UNDEF) {
-
   // Closure data
   // --------------------------------------------------------------------------
   var

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,9 +38,4 @@
   }
 
 })(typeof window === 'object' ? /* istanbul ignore next */ window : void 0) // eslint-disable-line no-void
-
-//#elif ES6
-
-export default {tmpl, brackets}
-
 //#endif

--- a/lib/tmpl.js
+++ b/lib/tmpl.js
@@ -6,10 +6,11 @@
  * tmpl.loopKeys - Get the keys for an 'each' loop (used by `_each`)
  */
 //#define LIST_GETTERS 0
-
 // IIFE for tmpl()
+//#if ES6
+export
+//#endif
 var tmpl = (function () {
-
   // Closure data
   // --------------------------------------------------------------------------
   var _cache = {}


### PR DESCRIPTION
I have optimized the `es6` export in order to require either `brackets` or `tmpl` simply by using:
```js
import { tmpl } from 'riot-tmpl'
```
The previous es6 dist did not allow this kind of syntax because we were always exporting one single default object:
```js
import tmpl from 'riot-tmpl'
// this sucks
var tmpl = tmpl.tmpl
```