### PR TITLE
Suppress default error message when user defined errorHandler is available

### DIFF
--- a/src/tmpl.js
+++ b/src/tmpl.js
@@ -122,8 +122,7 @@ var tmpl = (function () {
 
     // user error handler
     if (_tmpl.errorHandler) _tmpl.errorHandler(err)
-
-    if (
+    else if (
       typeof console !== 'undefined' &&
       typeof console.error === 'function'
     ) {

--- a/test/specs/core.specs.js
+++ b/test/specs/core.specs.js
@@ -437,6 +437,25 @@ describe('riot-tmpl', function () {
         expect(err).to.be.a('number')
       })
 
+      it('errors only in the user defined error handler (riot/2108)', function () {
+        var result, userErrOutput, defaultErrOutput
+
+        tmpl.errorHandler = function (e) { userErrOutput = e }
+        console.error = function (e) { defaultErrOutput = e }
+
+        data.root = { tagName: 'DIV' }
+        data._riot_id = 1
+        result = render('{ undefinedVar.property }')    // render as normal
+        delete data._riot_id
+        delete data.root
+
+        console.error = function () { /* noop */ } // eslint-disable-line
+        expect(result).to.be(undefined)
+        expect(userErrOutput instanceof Error).to.be(true)
+        expect(userErrOutput.riotData).to.eql({ tagName: 'DIV', _riot_id: 1 })
+        expect(defaultErrOutput).to.be(undefined)
+      })
+
       it('errors on instantiation of the getter always throws', function () {
         expect(render).withArgs('{ a: } }').to.throwError()  // SintaxError
         expect(render).withArgs('{ d c:1 }').to.throwError()


### PR DESCRIPTION
Closes https://github.com/riot/riot/issues/2108

This changes the behavior of error handling when user defined `errorHandler` is available:

- old: `errorHandler` + `console.error`
- new: `errorHandler`

Strictly speaking it's a breaking change. But, I think it's ok, in this case... :stuck_out_tongue_winking_eye: