### PR TITLE
[WIP] Adds test flag for CSP edition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ TESTCOVER = $(TRAVIS_BRANCH) $(TRAVIS_NODE_VERSION)
 # folders
 DIST = "./dist/"
 
-test: build test-mocha test-karma
+test: build test-mocha test-karma test-csp-mocha test-csp-karma
 
 build: eslint
 	# rebuild all
@@ -44,6 +44,13 @@ test-browsers:
 
 test-mocha:
 	@ $(ISTANBUL) cover --dir ./coverage/ist $(MOCHA) -- test/runner.js
+
+test-csp-karma:
+	# test for csp version
+	@ CSP_TEST_FLAG=1 $(KARMA) start test/karma.conf.js
+
+test-csp-mocha:
+	@ CSP_TEST_FLAG=1 $(MOCHA) test/runner.js
 
 send-coverage:
 	@ RIOT_COV=1 cat ./coverage/ist/lcov.info ./coverage/report-lcov/lcov.info | $(COVERALLS)

--- a/dist/csp.tmpl.js
+++ b/dist/csp.tmpl.js
@@ -6,37 +6,37 @@
 
 function InfiniteChecker (maxIterations) {
   if (this instanceof InfiniteChecker) {
-    this.maxIterations = maxIterations
-    this.count = 0
+    this.maxIterations = maxIterations;
+    this.count = 0;
   } else {
     return new InfiniteChecker(maxIterations)
   }
 }
 
 InfiniteChecker.prototype.check = function () {
-  this.count += 1
+  this.count += 1;
   if (this.count > this.maxIterations) {
     throw new Error('Infinite loop detected - reached max iterations')
   }
-}
+};
 
 function getGlobal (str) {
-  var ctx = (typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : this)
+  var ctx = (typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : this);
   return typeof str !== 'undefined' ? ctx[str] : ctx
 }
 
-var names = ['Object', 'String', 'Boolean', 'Number', 'RegExp', 'Date', 'Array']
-var immutable = { string: 'String', boolean: 'Boolean', number: 'Number' }
+var names = ['Object', 'String', 'Boolean', 'Number', 'RegExp', 'Date', 'Array'];
+var immutable = { string: 'String', boolean: 'Boolean', number: 'Number' };
 
-var primitives = names.map(getGlobal)
-var protos = primitives.map(getProto)
+var primitives = names.map(getGlobal);
+var protos = primitives.map(getProto);
 
 function Primitives (context) {
   if (this instanceof Primitives) {
-    this.context = context
+    this.context = context;
     for (var i = 0; i < names.length; i++) {
       if (!this.context[names[i]]) {
-        this.context[names[i]] = wrap(primitives[i])
+        this.context[names[i]] = wrap(primitives[i]);
       }
     }
   } else {
@@ -47,29 +47,29 @@ function Primitives (context) {
 Primitives.prototype.replace = function (value) {
   var primIndex = primitives.indexOf(value),
     protoIndex = protos.indexOf(value),
-    name
+    name;
 
   if (~primIndex) {
-    name = names[primIndex]
+    name = names[primIndex];
     return this.context[name]
   } else if (~protoIndex) {
-    name = names[protoIndex]
+    name = names[protoIndex];
     return this.context[name].prototype
   }
 
   return value
-}
+};
 
 Primitives.prototype.getPropertyObject = function (object, property) {
   if (immutable[typeof object]) {
     return this.getPrototypeOf(object)
   }
   return object
-}
+};
 
 Primitives.prototype.isPrimitive = function (value) {
   return !!~primitives.indexOf(value) || !!~protos.indexOf(value)
-}
+};
 
 Primitives.prototype.getPrototypeOf = function (value) {
   if (value == null) { // handle null and undefined
@@ -77,73 +77,73 @@ Primitives.prototype.getPrototypeOf = function (value) {
   }
 
   var immutableType = immutable[typeof value],
-    proto
+    proto;
 
   if (immutableType) {
-    proto = this.context[immutableType].prototype
+    proto = this.context[immutableType].prototype;
   } else {
-    proto = Object.getPrototypeOf(value)
+    proto = Object.getPrototypeOf(value);
   }
 
   if (!proto || proto === Object.prototype) {
     return null
   }
 
-  var replacement = this.replace(proto)
+  var replacement = this.replace(proto);
 
   if (replacement === value) {
-    replacement = this.replace(Object.prototype)
+    replacement = this.replace(Object.prototype);
   }
   return replacement
 
-}
+};
 
 Primitives.prototype.applyNew = function (func, args) {
   if (func.wrapped) {
-    var prim = Object.getPrototypeOf(func)
-    var instance = new (Function.prototype.bind.apply(prim, arguments))
+    var prim = Object.getPrototypeOf(func);
+    var instance = new (Function.prototype.bind.apply(prim, arguments));
 
-    setProto(instance, func.prototype)
+    setProto(instance, func.prototype);
     return instance
   }
 
   return new (Function.prototype.bind.apply(func, arguments))
 
-}
+};
 
 function getProto (func) {
   return func.prototype
 }
 
 function setProto (obj, proto) {
-  obj.__proto__ = proto // eslint-disable-line
+  obj.__proto__ = proto; // eslint-disable-line
 }
 
 function wrap (prim) {
-  var proto = Object.create(prim.prototype)
+  var proto = Object.create(prim.prototype);
 
   var result = function () {
     if (this instanceof result) {
-      prim.apply(this, arguments)
+      prim.apply(this, arguments);
     } else {
-      var instance = prim.apply(null, arguments)
+      var instance = prim.apply(null, arguments);
 
-      setProto(instance, proto)
+      setProto(instance, proto);
       return instance
     }
-  }
+  };
 
-  setProto(result, prim)
-  result.prototype = proto
-  result.wrapped = true
+  setProto(result, prim);
+  result.prototype = proto;
+  result.wrapped = true;
   return result
 }
 
-var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {}
+var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
 
-function interopDefault(ex) {
-	return ex && typeof ex === 'object' && 'default' in ex ? ex['default'] : ex;
-}
+
+
+
 
 function createCommonjsModule(fn, module) {
 	return module = { exports: {} }, fn(module, module.exports), module.exports;
@@ -1477,6 +1477,7 @@ var esprima = createCommonjsModule(function (module, exports) {
         try {
             return new RegExp(pattern, flags);
         } catch (exception) {
+            /* istanbul ignore next */
             return null;
         }
     }
@@ -1673,7 +1674,7 @@ var esprima = createCommonjsModule(function (module, exports) {
             return value && (value.length > 1) && (value[0] >= 'a') && (value[0] <= 'z');
         }
 
-        previous = extra.tokenValues[extra.tokens.length - 1];
+        previous = extra.tokenValues[extra.tokenValues.length - 1];
         regex = (previous !== null);
 
         switch (previous) {
@@ -5859,7 +5860,7 @@ var esprima = createCommonjsModule(function (module, exports) {
     }
 
     // Sync with *.json manifests.
-    exports.version = '2.7.2';
+    exports.version = '2.7.3';
 
     exports.tokenize = tokenize;
 
@@ -5891,73 +5892,70 @@ var esprima = createCommonjsModule(function (module, exports) {
 /* vim: set sw=4 ts=4 et tw=80 : */
 });
 
-var esprima$1 = interopDefault(esprima);
-
-var index = createCommonjsModule(function (module) {
-module.exports = hoist
+var index = hoist;
 
 function hoist(ast){
 
-  var parentStack = []
-  var variables = []
-  var functions = []
+  var parentStack = [];
+  var variables = [];
+  var functions = [];
 
   if (Array.isArray(ast)){
 
-    walkAll(ast)
-    prependScope(ast, variables, functions)
+    walkAll(ast);
+    prependScope(ast, variables, functions);
     
   } else {
-    walk(ast)
+    walk(ast);
   }
 
   return ast
 
   // walk through each node of a program of block statement
   function walkAll(nodes){
-    var result = null
+    var result = null;
     for (var i=0;i<nodes.length;i++){
-      var childNode = nodes[i]
+      var childNode = nodes[i];
       if (childNode.type === 'EmptyStatement') continue
-      var result = walk(childNode)
+      var result = walk(childNode);
       if (result === 'remove'){
-        nodes.splice(i--, 1)
+        nodes.splice(i--, 1);
       }
     }
   }
 
   function walk(node){
-    var parent = parentStack[parentStack.length-1]
-    var remove = false
-    parentStack.push(node)
+    var parent = parentStack[parentStack.length-1];
+    var remove = false;
+    parentStack.push(node);
 
-    var excludeBody = false
+    var excludeBody = false;
     if (shouldScope(node, parent)){
-      hoist(node.body)
-      excludeBody = true
+      hoist(node.body);
+      excludeBody = true;
     }
 
     if (node.type === 'VariableDeclarator'){
-      variables.push(node)
+      variables.push(node);
     }
 
     if (node.type === 'FunctionDeclaration'){
-      functions.push(node)
-      remove = true
+      functions.push(node);
+      remove = true;
     }
 
     for (var key in node){
       if (key === 'type' || (excludeBody && key === 'body')) continue
       if (key in node && node[key] && typeof node[key] == 'object'){
         if (node[key].type){
-          walk(node[key])
+          walk(node[key]);
         } else if (Array.isArray(node[key])){
-          walkAll(node[key])
+          walkAll(node[key]);
         }
       }
     }
 
-    parentStack.pop()
+    parentStack.pop();
     if (remove){
       return 'remove'
     }
@@ -5976,85 +5974,83 @@ function shouldScope(node, parent){
 
 function prependScope(nodes, variables, functions){
   if (variables && variables.length){
-    var declarations = []
+    var declarations = [];
     for (var i=0;i<variables.length;i++){
       declarations.push({
         type: 'VariableDeclarator', 
         id: variables[i].id,
         init: null
-      })
+      });
     }
     
     nodes.unshift({
       type: 'VariableDeclaration', 
       kind: 'var', 
       declarations: declarations
-    })
+    });
 
   }
 
   if (functions && functions.length){
     for (var i=0;i<functions.length;i++){
-      nodes.unshift(functions[i]) 
+      nodes.unshift(functions[i]); 
     }
   }
 }
-});
-
-var hoist = interopDefault(index);
 
 var maxIterations = 1000000;
-var parse = esprima$1.parse;
+var parse = esprima.parse;
+
 // 'eval' with a controlled environment
 function safeEval(src, parentContext){
-  var tree = prepareAst(src)
-  var context = Object.create(parentContext || {})
+  var tree = prepareAst(src);
+  var context = Object.create(parentContext || {});
   return finalValue(evaluateAst(tree, context))
 }
 
-safeEval.func = FunctionFactory()
+safeEval.func = FunctionFactory();
 
 // create a 'Function' constructor for a controlled environment
 function FunctionFactory(parentContext){
-  var context = Object.create(parentContext || {})
+  var context = Object.create(parentContext || {});
   return function Function() {
     // normalize arguments array
-    var args = Array.prototype.slice.call(arguments)
-    var src = args.slice(-1)[0]
-    args = args.slice(0,-1)
+    var args = Array.prototype.slice.call(arguments);
+    var src = args.slice(-1)[0];
+    args = args.slice(0,-1);
     if (typeof src === 'string'){
       //HACK: esprima doesn't like returns outside functions
-      src = parse('function a(){ ' + src + '}').body[0].body
+      src = parse('function a(){ ' + src + '}').body[0].body;
     }
-    var tree = prepareAst(src)
+    var tree = prepareAst(src);
     return getFunction(tree, args, context)
   }
 }
 
 // takes an AST or js source and returns an AST
 function prepareAst(src){
-  var tree = (typeof src === 'string') ? parse(src) : src
-  return hoist(tree)
+  var tree = (typeof src === 'string') ? parse(src) : src;
+  return index(tree)
 }
 
 // evaluate an AST in the given context
 function evaluateAst(tree, context){
 
-  var safeFunction = FunctionFactory(context)
-  var primitives = Primitives(context)
+  var safeFunction = FunctionFactory(context);
+  var primitives = Primitives(context);
 
   // block scoped context for catch (ex) and 'let'
-  var blockContext = context
+  var blockContext = context;
 
   return walk(tree)
 
   // recursively walk every node in an array
   function walkAll(nodes){
-    var result = undefined
+    var result = undefined;
     for (var i=0;i<nodes.length;i++){
-      var childNode = nodes[i]
+      var childNode = nodes[i];
       if (childNode.type === 'EmptyStatement') continue
-      result = walk(childNode)
+      result = walk(childNode);
       if (result instanceof ReturnValue){
         return result
       }
@@ -6072,25 +6068,25 @@ function evaluateAst(tree, context){
         return walkAll(node.body )
 
       case 'BlockStatement':
-        enterBlock()
-        var result = walkAll(node.body)
-        leaveBlock()
+        enterBlock();
+        var result = walkAll(node.body);
+        leaveBlock();
         return result
 
       case 'SequenceExpression':
         return walkAll(node.expressions)
 
       case 'FunctionDeclaration':
-        var params = node.params.map(getName)
-        var value = getFunction(node.body, params, blockContext)
+        var params = node.params.map(getName);
+        var value = getFunction(node.body, params, blockContext);
         return context[node.id.name] = value
 
       case 'FunctionExpression':
-        var params = node.params.map(getName)
+        var params = node.params.map(getName);
         return getFunction(node.body, params, blockContext)
 
       case 'ReturnStatement':
-        var value = walk(node.argument)
+        var value = walk(node.argument);
         return new ReturnValue('return', value)
 
       case 'BreakStatement':
@@ -6110,50 +6106,50 @@ function evaluateAst(tree, context){
 
       case 'VariableDeclaration':
         node.declarations.forEach(function(declaration){
-          var target = node.kind === 'let' ? blockContext : context
+          var target = node.kind === 'let' ? blockContext : context;
           if (declaration.init){
-            target[declaration.id.name] = walk(declaration.init)
+            target[declaration.id.name] = walk(declaration.init);
           } else {
-            target[declaration.id.name] = undefined
+            target[declaration.id.name] = undefined;
           }
-        })
+        });
         break
 
       case 'SwitchStatement':
-        var defaultHandler = null
-        var matched = false
-        var value = walk(node.discriminant)
-        var result = undefined
+        var defaultHandler = null;
+        var matched = false;
+        var value = walk(node.discriminant);
+        var result = undefined;
 
-        enterBlock()
+        enterBlock();
 
-        var i = 0
+        var i = 0;
         while (result == null){
           if (i<node.cases.length){
             if (node.cases[i].test){ // check or fall through
-              matched = matched || (walk(node.cases[i].test) === value)
+              matched = matched || (walk(node.cases[i].test) === value);
             } else if (defaultHandler == null) {
-              defaultHandler = i
+              defaultHandler = i;
             }
             if (matched){
-              var r = walkAll(node.cases[i].consequent)
+              var r = walkAll(node.cases[i].consequent);
               if (r instanceof ReturnValue){ // break out
                 if (r.type == 'break') break
-                result = r
+                result = r;
               }
             }
-            i += 1 // continue
+            i += 1; // continue
           } else if (!matched && defaultHandler != null){
             // go back and do the default handler
-            i = defaultHandler
-            matched = true
+            i = defaultHandler;
+            matched = true;
           } else {
             // nothing we can do
             break
           }
         }
 
-        leaveBlock()
+        leaveBlock();
         return result
 
       case 'IfStatement':
@@ -6164,84 +6160,84 @@ function evaluateAst(tree, context){
         }
 
       case 'ForStatement':
-        var infinite = InfiniteChecker(maxIterations)
-        var result = undefined
+        var infinite = InfiniteChecker(maxIterations);
+        var result = undefined;
 
-        enterBlock() // allow lets on delarations
+        enterBlock(); // allow lets on delarations
         for (walk(node.init); walk(node.test); walk(node.update)){
-          var r = walk(node.body)
+          var r = walk(node.body);
 
           // handle early return, continue and break
           if (r instanceof ReturnValue){
             if (r.type == 'continue') continue
             if (r.type == 'break') break
-            result = r
+            result = r;
             break
           }
 
-          infinite.check()
+          infinite.check();
         }
-        leaveBlock()
+        leaveBlock();
         return result
 
       case 'ForInStatement':
-        var infinite = InfiniteChecker(maxIterations)
-        var result = undefined
+        var infinite = InfiniteChecker(maxIterations);
+        var result = undefined;
 
-        var value = walk(node.right)
-        var property = node.left
+        var value = walk(node.right);
+        var property = node.left;
 
-        var target = context
-        enterBlock()
+        var target = context;
+        enterBlock();
 
         if (property.type == 'VariableDeclaration'){
-          walk(property)
-          property = property.declarations[0].id
+          walk(property);
+          property = property.declarations[0].id;
           if (property.kind === 'let'){
-            target = blockContext
+            target = blockContext;
           }
         }
 
         for (var key in value){
-          setValue(target, property, {type: 'Literal', value: key})
-          var r = walk(node.body)
+          setValue(target, property, {type: 'Literal', value: key});
+          var r = walk(node.body);
 
           // handle early return, continue and break
           if (r instanceof ReturnValue){
             if (r.type == 'continue') continue
             if (r.type == 'break') break
-            result = r
+            result = r;
             break
           }
 
-          infinite.check()
+          infinite.check();
         }
-        leaveBlock()
+        leaveBlock();
 
         return result
 
       case 'WhileStatement':
-        var infinite = InfiniteChecker(maxIterations)
+        var infinite = InfiniteChecker(maxIterations);
         while (walk(node.test)){
-          walk(node.body)
-          infinite.check()
+          walk(node.body);
+          infinite.check();
         }
         break
 
       case 'TryStatement':
         try {
-          walk(node.block)
+          walk(node.block);
         } catch (error) {
-          enterBlock()
-          var catchClause = node.handlers[0]
+          enterBlock();
+          var catchClause = node.handlers[0];
           if (catchClause) {
-            blockContext[catchClause.param.name] = error
-            walk(catchClause.body)
+            blockContext[catchClause.param.name] = error;
+            walk(catchClause.body);
           }
-          leaveBlock()
+          leaveBlock();
         } finally {
           if (node.finalizer) {
-            walk(node.finalizer)
+            walk(node.finalizer);
           }
         }
         break
@@ -6250,7 +6246,7 @@ function evaluateAst(tree, context){
         return node.value
 
       case 'UnaryExpression':
-        var val = walk(node.argument)
+        var val = walk(node.argument);
         switch(node.operator) {
           case '+': return +val
           case '-': return -val
@@ -6262,32 +6258,32 @@ function evaluateAst(tree, context){
         }
 
       case 'ArrayExpression':
-        var obj = blockContext['Array']()
+        var obj = blockContext['Array']();
         for (var i=0;i<node.elements.length;i++){
-          obj.push(walk(node.elements[i]))
+          obj.push(walk(node.elements[i]));
         }
         return obj
 
       case 'ObjectExpression':
-        var obj = blockContext['Object']()
+        var obj = blockContext['Object']();
         for (var i = 0; i < node.properties.length; i++) {
-          var prop = node.properties[i]
-          var value = (prop.value === null) ? prop.value : walk(prop.value)
-          obj[prop.key.value || prop.key.name] = value
+          var prop = node.properties[i];
+          var value = (prop.value === null) ? prop.value : walk(prop.value);
+          obj[prop.key.value || prop.key.name] = value;
         }
         return obj
 
       case 'NewExpression':
         var args = node.arguments.map(function(arg){
           return walk(arg)
-        })
-        var target = walk(node.callee)
+        });
+        var target = walk(node.callee);
         return primitives.applyNew(target, args)
 
 
       case 'BinaryExpression':
-        var l = walk(node.left)
-        var r = walk(node.right)
+        var l = walk(node.left);
+        var r = walk(node.right);
 
         switch(node.operator) {
           case '==':  return l === r
@@ -6334,27 +6330,27 @@ function evaluateAst(tree, context){
 
         var args = node.arguments.map(function(arg){
           return walk(arg)
-        })
-        var object = null
-        var target = walk(node.callee)
+        });
+        var object = null;
+        var target = walk(node.callee);
 
         if (node.callee.type === 'MemberExpression'){
-          object = walk(node.callee.object)
+          object = walk(node.callee.object);
         }
         return target.apply(object, args)
 
       case 'MemberExpression':
-        var obj = walk(node.object)
+        var obj = walk(node.object);
         if (node.computed){
-          var prop = walk(node.property)
+          var prop = walk(node.property);
         } else {
-          var prop = node.property.name
+          var prop = node.property.name;
         }
-        obj = primitives.getPropertyObject(obj, prop)
+        obj = primitives.getPropertyObject(obj, prop);
         return checkValue(obj[prop]);
 
       case 'ConditionalExpression':
-        var val = walk(node.test)
+        var val = walk(node.test);
         return val ? walk(node.consequent) : walk(node.alternate)
 
       case 'EmptyStatement':
@@ -6368,34 +6364,34 @@ function evaluateAst(tree, context){
   // safely retrieve a value
   function checkValue(value){
     if (value === Function){
-      value = safeFunction
+      value = safeFunction;
     }
     return finalValue(value)
   }
 
   // block scope context control
   function enterBlock(){
-    blockContext = Object.create(blockContext)
+    blockContext = Object.create(blockContext);
   }
   function leaveBlock(){
-    blockContext = Object.getPrototypeOf(blockContext)
+    blockContext = Object.getPrototypeOf(blockContext);
   }
 
   // set a value in the specified context if allowed
   function setValue(object, left, right, operator){
-    var name = null
+    var name = null;
 
     if (left.type === 'Identifier'){
-      name = left.name
+      name = left.name;
       // handle parent context shadowing
-      object = objectForKey(object, name, primitives)
+      object = objectForKey(object, name, primitives);
     } else if (left.type === 'MemberExpression'){
       if (left.computed){
-        name = walk(left.property)
+        name = walk(left.property);
       } else {
-        name = left.property.name
+        name = left.property.name;
       }
-      object = walk(left.object)
+      object = walk(left.object);
     }
 
     // stop built in properties from being able to be changed
@@ -6416,15 +6412,15 @@ function evaluateAst(tree, context){
 
 // when an unsupported expression is encountered, throw an error
 function unsupportedExpression(node){
-  console.error(node)
-  var err = new Error('Unsupported expression: ' + node.type)
-  err.node = node
+  console.error(node);
+  var err = new Error('Unsupported expression: ' + node.type);
+  err.node = node;
   throw err
 }
 
 // walk a provided object's prototypal hierarchy to retrieve an inherited object
 function objectForKey(object, key, primitives){
-  var proto = primitives.getPrototypeOf(object)
+  var proto = primitives.getPrototypeOf(object);
   if (!proto || hasOwnProperty(object, key)){
     return object
   } else {
@@ -6433,8 +6429,8 @@ function objectForKey(object, key, primitives){
 }
 
 function hasProperty(object, key, primitives){
-  var proto = primitives.getPrototypeOf(object)
-  var hasOwn = hasOwnProperty(object, key)
+  var proto = primitives.getPrototypeOf(object);
+  var hasOwn = hasOwnProperty(object, key);
   if (object[key] !== undefined){
     return true
   } else if (!proto || hasOwn){
@@ -6478,25 +6474,25 @@ function canSetProperty(object, property, primitives){
 function getFunction(body, params, parentContext){
   return function(){
     var context = Object.create(parentContext),
-      g = getGlobal()
+      g = getGlobal();
 
-    context['window'] = context['global'] = g
+    context['window'] = context['global'] = g;
 
     if (this == g) {
-      context['this'] = null
+      context['this'] = null;
     } else {
-      context['this'] = this
+      context['this'] = this;
     }
     // normalize arguments array
-    var args = Array.prototype.slice.call(arguments)
-    context['arguments'] = arguments
+    var args = Array.prototype.slice.call(arguments);
+    context['arguments'] = arguments;
     args.forEach(function(arg,idx){
-      var param = params[idx]
+      var param = params[idx];
       if (param){
-        context[param] = arg
+        context[param] = arg;
       }
-    })
-    var result = evaluateAst(body, context)
+    });
+    var result = evaluateAst(body, context);
 
     if (result instanceof ReturnValue){
       return result.value
@@ -6518,11 +6514,9 @@ function getName(identifier){
 
 // a ReturnValue struct for differentiating between expression result and return statement
 function ReturnValue(type, value){
-  this.type = type
-  this.value = value
+  this.type = type;
+  this.value = value;
 }
-
-//eslint-disable-line no-unused-vars
 
 /**
  * The riot template engine
@@ -6562,7 +6556,7 @@ var brackets = (function (UNDEF) {
       '{': RegExp('([{}])|'   + S_QBLOCKS, REGLOB)
     },
 
-    DEFAULT = '{ }'
+    DEFAULT = '{ }';
 
   var _pairs = [
     '{', '}',
@@ -6574,18 +6568,18 @@ var brackets = (function (UNDEF) {
     DEFAULT,
     /^\s*{\^?\s*([$\w]+)(?:\s*,\s*(\S+))?\s+in\s+(\S.*)\s*}/,
     /(^|[^\\]){=[\S\s]*?}/
-  ]
+  ];
 
   var
     cachedBrackets = UNDEF,
     _regex,
     _cache = [],
-    _settings
+    _settings;
 
   function _loopback (re) { return re }
 
   function _rewrite (re, bp) {
-    if (!bp) bp = _cache
+    if (!bp) bp = _cache;
     return new RegExp(
       re.source.replace(/{/g, bp[2]).replace(/}/g, bp[3]), re.global ? REGLOB : ''
     )
@@ -6594,18 +6588,18 @@ var brackets = (function (UNDEF) {
   function _create (pair) {
     if (pair === DEFAULT) return _pairs
 
-    var arr = pair.split(' ')
+    var arr = pair.split(' ');
 
     if (arr.length !== 2 || UNSUPPORTED.test(pair)) {
       throw new Error('Unsupported brackets "' + pair + '"')
     }
-    arr = arr.concat(pair.replace(NEED_ESCAPE, '\\').split(' '))
+    arr = arr.concat(pair.replace(NEED_ESCAPE, '\\').split(' '));
 
-    arr[4] = _rewrite(arr[1].length > 1 ? /{[\S\s]*?}/ : _pairs[4], arr)
-    arr[5] = _rewrite(pair.length > 3 ? /\\({|})/g : _pairs[5], arr)
-    arr[6] = _rewrite(_pairs[6], arr)
-    arr[7] = RegExp('\\\\(' + arr[3] + ')|([[({])|(' + arr[3] + ')|' + S_QBLOCKS, REGLOB)
-    arr[8] = pair
+    arr[4] = _rewrite(arr[1].length > 1 ? /{[\S\s]*?}/ : _pairs[4], arr);
+    arr[5] = _rewrite(pair.length > 3 ? /\\({|})/g : _pairs[5], arr);
+    arr[6] = _rewrite(_pairs[6], arr);
+    arr[7] = RegExp('\\\\(' + arr[3] + ')|([[({])|(' + arr[3] + ')|' + S_QBLOCKS, REGLOB);
+    arr[8] = pair;
     return arr
   }
 
@@ -6615,7 +6609,7 @@ var brackets = (function (UNDEF) {
 
   _brackets.split = function split (str, tmpl, _bp) {
     // istanbul ignore next: _bp is for the compiler
-    if (!_bp) _bp = _cache
+    if (!_bp) _bp = _cache;
 
     var
       parts = [],
@@ -6623,18 +6617,18 @@ var brackets = (function (UNDEF) {
       isexpr,
       start,
       pos,
-      re = _bp[6]
+      re = _bp[6];
 
-    isexpr = start = re.lastIndex = 0
+    isexpr = start = re.lastIndex = 0;
 
     while ((match = re.exec(str))) {
 
-      pos = match.index
+      pos = match.index;
 
       if (isexpr) {
 
         if (match[2]) {
-          re.lastIndex = skipBraces(str, match[2], re.lastIndex)
+          re.lastIndex = skipBraces(str, match[2], re.lastIndex);
           continue
         }
         if (!match[3]) {
@@ -6643,97 +6637,97 @@ var brackets = (function (UNDEF) {
       }
 
       if (!match[1]) {
-        unescapeStr(str.slice(start, pos))
-        start = re.lastIndex
-        re = _bp[6 + (isexpr ^= 1)]
-        re.lastIndex = start
+        unescapeStr(str.slice(start, pos));
+        start = re.lastIndex;
+        re = _bp[6 + (isexpr ^= 1)];
+        re.lastIndex = start;
       }
     }
 
     if (str && start < str.length) {
-      unescapeStr(str.slice(start))
+      unescapeStr(str.slice(start));
     }
 
     return parts
 
     function unescapeStr (s) {
       if (tmpl || isexpr) {
-        parts.push(s && s.replace(_bp[5], '$1'))
+        parts.push(s && s.replace(_bp[5], '$1'));
       } else {
-        parts.push(s)
+        parts.push(s);
       }
     }
 
     function skipBraces (s, ch, ix) {
       var
         match,
-        recch = FINDBRACES[ch]
+        recch = FINDBRACES[ch];
 
-      recch.lastIndex = ix
-      ix = 1
+      recch.lastIndex = ix;
+      ix = 1;
       while ((match = recch.exec(s))) {
         if (match[1] &&
           !(match[1] === ch ? ++ix : --ix)) break
       }
       return ix ? s.length : recch.lastIndex
     }
-  }
+  };
 
   _brackets.hasExpr = function hasExpr (str) {
     return _cache[4].test(str)
-  }
+  };
 
   _brackets.loopKeys = function loopKeys (expr) {
-    var m = expr.match(_cache[9])
+    var m = expr.match(_cache[9]);
 
     return m
       ? { key: m[1], pos: m[2], val: _cache[0] + m[3].trim() + _cache[1] }
       : { val: expr.trim() }
-  }
+  };
 
   _brackets.array = function array (pair) {
     return pair ? _create(pair) : _cache
-  }
+  };
 
   function _reset (pair) {
     if ((pair || (pair = DEFAULT)) !== _cache[8]) {
-      _cache = _create(pair)
-      _regex = pair === DEFAULT ? _loopback : _rewrite
-      _cache[9] = _regex(_pairs[9])
+      _cache = _create(pair);
+      _regex = pair === DEFAULT ? _loopback : _rewrite;
+      _cache[9] = _regex(_pairs[9]);
     }
-    cachedBrackets = pair
+    cachedBrackets = pair;
   }
 
   function _setSettings (o) {
-    var b
+    var b;
 
-    o = o || {}
-    b = o.brackets
+    o = o || {};
+    b = o.brackets;
     Object.defineProperty(o, 'brackets', {
       set: _reset,
       get: function () { return cachedBrackets },
       enumerable: true
-    })
-    _settings = o
-    _reset(b)
+    });
+    _settings = o;
+    _reset(b);
   }
 
   Object.defineProperty(_brackets, 'settings', {
     set: _setSettings,
     get: function () { return _settings }
-  })
+  });
 
   /* istanbul ignore next: in the browser riot is always in the scope */
-  _brackets.settings = typeof riot !== 'undefined' && riot.settings || {}
-  _brackets.set = _reset
+  _brackets.settings = typeof riot !== 'undefined' && riot.settings || {};
+  _brackets.set = _reset;
 
-  _brackets.R_STRINGS = R_STRINGS
-  _brackets.R_MLCOMMS = R_MLCOMMS
-  _brackets.S_QBLOCKS = S_QBLOCKS
+  _brackets.R_STRINGS = R_STRINGS;
+  _brackets.R_MLCOMMS = R_MLCOMMS;
+  _brackets.S_QBLOCKS = S_QBLOCKS;
 
   return _brackets
 
-})()
+})();
 
 /**
  * @module tmpl
@@ -6745,7 +6739,7 @@ var brackets = (function (UNDEF) {
 
 var tmpl = (function () {
 
-  var _cache = {}
+  var _cache = {};
 
   function _tmpl (str, data) {
     if (!str) return str
@@ -6753,39 +6747,39 @@ var tmpl = (function () {
     return (_cache[str] || (_cache[str] = _create(str))).call(data, _logErr)
   }
 
-  _tmpl.hasExpr = brackets.hasExpr
+  _tmpl.hasExpr = brackets.hasExpr;
 
-  _tmpl.loopKeys = brackets.loopKeys
+  _tmpl.loopKeys = brackets.loopKeys;
 
   // istanbul ignore next
-  _tmpl.clearCache = function () { _cache = {} }
+  _tmpl.clearCache = function () { _cache = {}; };
 
-  _tmpl.errorHandler = null
+  _tmpl.errorHandler = null;
 
   function _logErr (err, ctx) {
 
     err.riotData = {
       tagName: ctx && ctx.root && ctx.root.tagName,
       _riot_id: ctx && ctx._riot_id  //eslint-disable-line camelcase
-    }
+    };
 
-    if (_tmpl.errorHandler) _tmpl.errorHandler(err)
+    if (_tmpl.errorHandler) _tmpl.errorHandler(err);
 
     if (
       typeof console !== 'undefined' &&
       typeof console.error === 'function'
     ) {
       if (err.riotData.tagName) {
-        console.error('Riot template error thrown in the <%s> tag', err.riotData.tagName)
+        console.error('Riot template error thrown in the <%s> tag', err.riotData.tagName);
       }
-      console.error(err)
+      console.error(err);
     }
   }
 
   function _create (str) {
-    var expr = _getTmpl(str)
+    var expr = _getTmpl(str);
 
-    if (expr.slice(0, 11) !== 'try{return ') expr = 'return ' + expr
+    if (expr.slice(0, 11) !== 'try{return ') expr = 'return ' + expr;
 
     return safeEval.func('E', expr + ';')
   }
@@ -6795,20 +6789,20 @@ var tmpl = (function () {
     RE_CSNAME = /^(?:(-?[_A-Za-z\xA0-\xFF][-\w\xA0-\xFF]*)|\u2057(\d+)~):/,
     RE_QBLOCK = RegExp(brackets.S_QBLOCKS, 'g'),
     RE_DQUOTE = /\u2057/g,
-    RE_QBMARK = /\u2057(\d+)~/g
+    RE_QBMARK = /\u2057(\d+)~/g;
 
   function _getTmpl (str) {
     var
       qstr = [],
       expr,
-      parts = brackets.split(str.replace(RE_DQUOTE, '"'), 1)
+      parts = brackets.split(str.replace(RE_DQUOTE, '"'), 1);
 
     if (parts.length > 2 || parts[0]) {
-      var i, j, list = []
+      var i, j, list = [];
 
       for (i = j = 0; i < parts.length; ++i) {
 
-        expr = parts[i]
+        expr = parts[i];
 
         if (expr && (expr = i & 1
 
@@ -6820,16 +6814,16 @@ var tmpl = (function () {
                 .replace(/"/g, '\\"') +
               '"'
 
-          )) list[j++] = expr
+          )) list[j++] = expr;
 
       }
 
       expr = j < 2 ? list[0]
-           : '[' + list.join(',') + '].join("")'
+           : '[' + list.join(',') + '].join("")';
 
     } else {
 
-      expr = _parseExpr(parts[1], 0, qstr)
+      expr = _parseExpr(parts[1], 0, qstr);
     }
 
     if (qstr[0]) {
@@ -6837,7 +6831,7 @@ var tmpl = (function () {
         return qstr[pos]
           .replace(/\r/g, '\\r')
           .replace(/\n/g, '\\n')
-      })
+      });
     }
     return expr
   }
@@ -6847,7 +6841,7 @@ var tmpl = (function () {
       '(': /[()]/g,
       '[': /[[\]]/g,
       '{': /[{}]/g
-    }
+    };
 
   function _parseExpr (expr, asText, qstr) {
 
@@ -6856,13 +6850,13 @@ var tmpl = (function () {
             return s.length > 2 && !div ? CH_IDEXPR + (qstr.push(s) - 1) + '~' : s
           })
           .replace(/\s+/g, ' ').trim()
-          .replace(/\ ?([[\({},?\.:])\ ?/g, '$1')
+          .replace(/\ ?([[\({},?\.:])\ ?/g, '$1');
 
     if (expr) {
       var
         list = [],
         cnt = 0,
-        match
+        match;
 
       while (expr &&
             (match = expr.match(RE_CSNAME)) &&
@@ -6871,21 +6865,21 @@ var tmpl = (function () {
         var
           key,
           jsb,
-          re = /,|([[{(])|$/g
+          re = /,|([[{(])|$/g;
 
-        expr = RegExp.rightContext
-        key  = match[2] ? qstr[match[2]].slice(1, -1).trim().replace(/\s+/g, ' ') : match[1]
+        expr = RegExp.rightContext;
+        key  = match[2] ? qstr[match[2]].slice(1, -1).trim().replace(/\s+/g, ' ') : match[1];
 
-        while (jsb = (match = re.exec(expr))[1]) skipBraces(jsb, re)
+        while (jsb = (match = re.exec(expr))[1]) skipBraces(jsb, re);
 
-        jsb  = expr.slice(0, match.index)
-        expr = RegExp.rightContext
+        jsb  = expr.slice(0, match.index);
+        expr = RegExp.rightContext;
 
-        list[cnt++] = _wrapExpr(jsb, 1, key)
+        list[cnt++] = _wrapExpr(jsb, 1, key);
       }
 
       expr = !cnt ? _wrapExpr(expr, asText)
-           : cnt > 1 ? '[' + list.join(',') + '].join(" ").trim()' : list[0]
+           : cnt > 1 ? '[' + list.join(',') + '].join(" ").trim()' : list[0];
     }
     return expr
 
@@ -6893,14 +6887,14 @@ var tmpl = (function () {
       var
         mm,
         lv = 1,
-        ir = RE_BREND[ch]
+        ir = RE_BREND[ch];
 
-      ir.lastIndex = re.lastIndex
+      ir.lastIndex = re.lastIndex;
       while (mm = ir.exec(expr)) {
-        if (mm[0] === ch) ++lv
+        if (mm[0] === ch) ++lv;
         else if (!--lv) break
       }
-      re.lastIndex = lv ? expr.length : ir.lastIndex
+      re.lastIndex = lv ? expr.length : ir.lastIndex;
     }
   }
 
@@ -6908,50 +6902,50 @@ var tmpl = (function () {
   var // eslint-disable-next-line max-len
     JS_CONTEXT = '"in this?this:' + (typeof window !== 'object' ? 'global' : 'window') + ').',
     JS_VARNAME = /[,{][\$\w]+(?=:)|(^ *|[^$\w\.{])(?!(?:typeof|true|false|null|undefined|in|instanceof|is(?:Finite|NaN)|void|NaN|new|Date|RegExp|Math)(?![$\w]))([$_A-Za-z][$\w]*)/g,
-    JS_NOPROPS = /^(?=(\.[$\w]+))\1(?:[^.[(]|$)/
+    JS_NOPROPS = /^(?=(\.[$\w]+))\1(?:[^.[(]|$)/;
 
   function _wrapExpr (expr, asText, key) {
-    var tb
+    var tb;
 
     expr = expr.replace(JS_VARNAME, function (match, p, mvar, pos, s) {
       if (mvar) {
-        pos = tb ? 0 : pos + match.length
+        pos = tb ? 0 : pos + match.length;
 
         if (mvar !== 'this' && mvar !== 'global' && mvar !== 'window') {
-          match = p + '("' + mvar + JS_CONTEXT + mvar
-          if (pos) tb = (s = s[pos]) === '.' || s === '(' || s === '['
+          match = p + '("' + mvar + JS_CONTEXT + mvar;
+          if (pos) tb = (s = s[pos]) === '.' || s === '(' || s === '[';
         } else if (pos) {
-          tb = !JS_NOPROPS.test(s.slice(pos))
+          tb = !JS_NOPROPS.test(s.slice(pos));
         }
       }
       return match
-    })
+    });
 
     if (tb) {
-      expr = 'try{return ' + expr + '}catch(e){E(e,this)}'
+      expr = 'try{return ' + expr + '}catch(e){E(e,this)}';
     }
 
     if (key) {
 
       expr = (tb
           ? 'function(){' + expr + '}.call(this)' : '(' + expr + ')'
-        ) + '?"' + key + '":""'
+        ) + '?"' + key + '":""';
 
     } else if (asText) {
 
       expr = 'function(v){' + (tb
           ? expr.replace('return ', 'v=') : 'v=(' + expr + ')'
-        ) + ';return v||v===0?v:""}.call(this)'
+        ) + ';return v||v===0?v:""}.call(this)';
     }
 
     return expr
   }
 
-  _tmpl.version = brackets.version = 'WIP'
+  _tmpl.version = brackets.version = 'WIP';
 
   return _tmpl
 
-})()
+})();
 
 exports.brackets = brackets;
 exports.tmpl = tmpl;

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -23,7 +23,7 @@ module.exports = function (config) {
 
     files: [
       '../node_modules/expect.js/index.js',
-      '../dist/tmpl.js',
+      process.env.CSP_TEST_FLAG ? '../dist/csp.tmpl.js' : '../dist/tmpl.js',
       'specs/core.specs.js',
       'specs/brackets.specs.js'
     ],

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,8 +1,9 @@
 describe('Tmpl Tests', function () {
 
+  var tmplPath = process.env.CSP_TEST_FLAG ? '../dist/csp.tmpl' : '../dist/tmpl'
   expect   = require('expect.js')
-  tmpl     = require('../dist/tmpl').tmpl
-  brackets = require('../dist/tmpl').brackets
+  tmpl     = require(tmplPath).tmpl
+  brackets = require(tmplPath).brackets
 
   require('./specs/core.specs.js')
   require('./specs/brackets.specs.js')


### PR DESCRIPTION
Currently CSP edition fails 15 tests (out of 70). Is it an expected behavior?
If not, I'd like to dive into the code more.

#### Output from mocha

- [ ] Tmpl Tests riot-tmpl compiles specs expressions are just regular JavaScript:
   Error: expected undefined to equal 2
- [ ] Tmpl Tests riot-tmpl compiles specs class shorthands expressions are just regular JavaScript:
   Error: expected '' to equal 'y'
- [ ] Tmpl Tests riot-tmpl compiles specs class shorthands even function calls, objects and arrays are no problem:
   Error: expected '' to equal 'ok'
- [ ] Tmpl Tests riot-tmpl 2.2.3 few errors in recognizing complex expressions:
   Error: expected '' to equal 'primary'
- [ ] Tmpl Tests riot-tmpl 2.2.3 unwrapped keywords void, window and global, in addition to `this`:
   Error: expected undefined to be an object
- [ ] Tmpl Tests riot-tmpl 2.2.3 you can include almost anything in quoted shorhand names:
   Error: expected undefined to equal 1
- [ ] Tmpl Tests riot-tmpl 2.2.3 main inconsistence between expressions and class shorthands are gone:
   Error: expected 'Leto\'s house ' to equal ' '
- [ ] Tmpl Tests riot-tmpl 2.3.0 does not wrap global and window object names:
   Error: expected undefined to be a number
- [ ] Tmpl Tests riot-tmpl 2.3.0 unwrapped keywords: Infinity, isFinite, isNaN, Date, RegExp and Math:
   ReferenceError: isFinite is not defined
- [ ] Tmpl Tests riot-tmpl 2.3.0 Fix riot#2002 issue with the `JS_VARNAME` regex failing in iOS 9.3.0:
   Error: expected undefined to equal 'Please choose from the 1 stores available'
- [ ] Tmpl Tests riot-tmpl 2.3.0 catch errors in expressions with tmpl.errorHandler GOTCHA: null as param for call([this]) defaults to global too:
    Error: expected { tagName: null, _riot_id: null } to sort of equal { tagName: undefined, _riot_id: undefined }
- [ ] Tmpl Tests brackets single and multi character custom brackets:
   Error: expected undefined to equal 'x'
- [ ] Tmpl Tests brackets using brackets inside expressions though escaping is optional:
   Error: expected undefined to equal '{"x":5}'
- [ ] Tmpl Tests brackets 2.2.3 escaping is almost unnecessary with custom brackets to "[ ]" (bad idea):
   Error: expected undefined to equal 'x'
- [ ] Tmpl Tests brackets 2.2.3 escaping is almost unnecessary with custom brackets to "( )" (another bad idea):
   Error: expected undefined to equal 'x'